### PR TITLE
docs: remove PR checklist from template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -4,9 +4,3 @@ _High_level_PR_description_
 
 ### Updates
 * _list_of_updates_
-
----
-
-- [ ] Package dependencies have been updated (where possible)
-- [ ] Documentation has been updated
-- [ ] Automated tests have been updated


### PR DESCRIPTION
## Remove PR Checklist

The PR checklist has been in use for a while now. I feel that it doesn't quite hit the mark with it's intention and ~~is mostly more of an annoyance than anything~~ can often lead to confusion as the items are rarely all relevant which leads to developers having seemingly not done something they "should have"  .

I'd love to hear if anyone is seeing any benefit from this list and more than happy to leave it in if so.

### Updates
* Remove checklist from PR template 2c0325a6a0bb7d70da274ac9e40ec54cf3a0a40d

---

Case in point.... 😄 

- [ ] Package dependencies have been updated (where possible)
- [ ] Documentation has been updated
- [ ] Automated tests have been updated
